### PR TITLE
feat: add cocurrency mode and batch_decode method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "bech32"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,7 +518,7 @@ dependencies = [
  "log",
  "lru",
  "parking_lot",
- "reqwest",
+ "reqwest 0.11.27",
  "secp256k1",
  "serde",
  "serde_derive",
@@ -736,8 +742,10 @@ dependencies = [
  "ckb-types",
  "ckb-vm",
  "hex",
+ "jsonrpc-core",
  "jsonrpsee",
  "lazy_static",
+ "reqwest 0.12.4",
  "serde",
  "serde_json",
  "spore-types",
@@ -1023,7 +1031,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1085,13 +1112,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -1117,9 +1178,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.25",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1132,16 +1193,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1245,7 +1362,7 @@ dependencies = [
  "async-trait",
  "beef",
  "futures-util",
- "hyper",
+ "hyper 0.14.28",
  "jsonrpsee-types",
  "parking_lot",
  "rand 0.8.5",
@@ -1277,8 +1394,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4882e640e70c2553e3d9487e6f4dddd5fd11918f25e40fa45218f9fe29ed2152"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "pin-project",
@@ -1937,11 +2054,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
+ "h2 0.3.25",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -1950,7 +2067,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1963,7 +2080,49 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.1.2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -2014,6 +2173,22 @@ checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.0",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
 
 [[package]]
 name = "ryu"
@@ -2278,7 +2453,7 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "futures",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -2553,6 +2728,11 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3022,6 +3202,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if 1.0.0",
  "windows-sys 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ dependencies = [
  "ckb-sdk",
  "ckb-types",
  "ckb-vm",
+ "futures",
  "hex",
  "jsonrpc-core",
  "jsonrpsee",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ hex = "0.4.3"
 reqwest = { version = "0.12.4", features = ["json"] }
 jsonrpc-core = "18.0"
 serde = { version = "1.0", features = ["serde_derive"] }
+lazy_static = { version = "1.4" }
+ckb-vm = { version = "0.24", features = ["asm"] }
 
 spore-types = { git = "https://github.com/sporeprotocol/spore-contract", rev = "81315ca" }
 
@@ -24,11 +26,7 @@ toml = { version = "0.8.2", optional = true }
 tokio = { version = "1.37", features = ["rt", "signal"], optional = true }
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"], optional = true }
 
-lazy_static = { version = "1.4", optional = true }
-ckb-vm = { version = "0.24", features = ["asm"], optional = true }
-
 [features]
-default = ["standalone_server", "embeded_vm", "render_debug"]
+default = ["standalone_server", "render_debug"]
 standalone_server = ["jsonrpsee", "toml", "tokio", "tracing-subscriber"]
-embeded_vm = ["ckb-vm", "lazy_static"]
 render_debug = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ hex = "0.4.3"
 reqwest = { version = "0.12.4", features = ["json"] }
 jsonrpc-core = "18.0"
 serde = { version = "1.0", features = ["serde_derive"] }
+futures = "0.3"
 lazy_static = { version = "1.4" }
 ckb-vm = { version = "0.24", features = ["asm"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ ckb-hash = "0.114.0"
 thiserror = "1.0"
 serde_json = "1.0"
 hex = "0.4.3"
+reqwest = { version = "0.12.4", features = ["json"] }
+jsonrpc-core = "18.0"
 serde = { version = "1.0", features = ["serde_derive"] }
 
 spore-types = { git = "https://github.com/sporeprotocol/spore-contract", rev = "81315ca" }

--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ $ echo '{
 }' \
 | curl -H 'content-type: application/json' -d @- \
 http://localhost:8090
+
+or
+
+$ echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "dob_batch_decode",
+    "params": [
+        [
+            "<spore_id in hex format without 0x prefix>",
+            "<spore_id in hex format without 0x prefix>",
+            ...
+        ]
+    ]
+}' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8090
 ```
 
 ## Protocol version
@@ -95,6 +112,8 @@ refer to error definitions [here](https://github.com/sporeprotocol/dob-decoder-s
 | 1020 | NoOutputCellInTransaction |
 | 1021 | DOBContentUnexpected |
 | 1022 | DOBMetadataUnexpected |
-| 1023 | DOBRenderCacheModified |
-| 1024 | DecoderBinaryHashInvalid |
-| 1025 | DecoderBinaryNotFoundInCell |
+| 1023 | DOBRenderCacheNotFound |
+| 1024 | DOBRenderCacheModified |
+| 1025 | DecoderBinaryHashInvalid |
+| 1026 | DecoderBinaryNotFoundInCell |
+| 1027 | JsonRpcRequestError |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Provide an one-step DOB rendering service to squash a batch of complex steps that from DNA fetching to DOB traits rendering.
 
 Online features:
-- [x] native or embeded `ckb-vm` executor
+- [x] embeded `ckb-vm` executor
 - [x] executable standalone JsonRpc server
 - [x] decoder binaries temporary cache
 - [x] render result temporary cache
@@ -11,18 +11,7 @@ Online features:
 
 ## `ckb-vm` executor
 
-There are two execution modes: native and embeded.
-
-Native mode requires running a pre-installed standalone `ckb-vm` parser in the machine that decoder server runs on, which binary name is highlighted [here](https://github.com/sporeprotocol/dob-decoder-standalone-server/blob/master/settings.toml#L11).
-
-Steps to install a recommended `ckb-vm` runner:
-
-```bash
-$ git clone https://github.com/nervosnetwork/ckb-vm
-$ cargo install --path . --example ckb-vm-runner
-```
-
-Embeded mode is integrating a standalone `ckb-vm` in project to execute decoder binary files, and the corresponding feature is `embeded_vm` which is marked in [default](https://github.com/sporeprotocol/dob-decoder-standalone-server/blob/master/Cargo.toml#L27). We recommend embeded mode for fresh users, because in contrast, the native mode is more like an advanced usage for providing flexibility for user-defined VM environments.
+Embeded VM executor is integrating a standalone `ckb-vm` in project to execute decoder binary files, and the corresponding feature is `embeded_vm` which is marked in [default](https://github.com/sporeprotocol/dob-decoder-standalone-server/blob/master/Cargo.toml#L27). We recommend embeded mode for fresh users, because in contrast, the native mode is more like an advanced usage for providing flexibility for user-defined VM environments.
 
 ## Decoder binaries cache
 
@@ -73,8 +62,7 @@ $ echo '{
             "<spore_id in hex format without 0x prefix>",
             "<spore_id in hex format without 0x prefix>",
             ...
-        ],
-        <true or false, which considers one piece of errors as the whole request error>
+        ]
     ]
 }' \
 | curl -H 'content-type: application/json' -d @- \

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ $ echo '{
             "<spore_id in hex format without 0x prefix>",
             "<spore_id in hex format without 0x prefix>",
             ...
-        ]
+        ],
+        <true or false, which considers one piece of errors as the whole request error>
     ]
 }' \
 | curl -H 'content-type: application/json' -d @- \

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,7 +10,7 @@ use reqwest::{Client, Url};
 
 use crate::types::Error;
 
-pub type RPC<T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'static>>;
+pub type Rpc<T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'static>>;
 
 #[allow(clippy::upper_case_acronyms)]
 enum Target {
@@ -80,7 +80,7 @@ impl RpcClient {
 }
 
 impl RpcClient {
-    pub fn get_live_cell(&self, out_point: &OutPoint, with_data: bool) -> RPC<CellWithStatus> {
+    pub fn get_live_cell(&self, out_point: &OutPoint, with_data: bool) -> Rpc<CellWithStatus> {
         jsonrpc!(
             "get_live_cell",
             Target::CKB,
@@ -97,7 +97,7 @@ impl RpcClient {
         search_key: SearchKey,
         limit: u32,
         cursor: Option<JsonBytes>,
-    ) -> RPC<Pagination<Cell>> {
+    ) -> Rpc<Pagination<Cell>> {
         let order = Order::Asc;
         let limit = Uint32::from(limit);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,116 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use ckb_jsonrpc_types::{CellWithStatus, JsonBytes, OutPoint, Uint32};
+use ckb_sdk::rpc::ckb_indexer::{Cell, Order, Pagination, SearchKey};
+use jsonrpc_core::futures::FutureExt;
+use reqwest::{Client, Url};
+
+use crate::types::Error;
+
+pub type RPC<T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'static>>;
+
+#[allow(clippy::upper_case_acronyms)]
+enum Target {
+    CKB,
+    Indexer,
+}
+
+macro_rules! jsonrpc {
+    ($method:expr, $id:expr, $self:ident, $return:ty$(, $params:ident$(,)?)*) => {{
+        let data = format!(
+            r#"{{"id": {}, "jsonrpc": "2.0", "method": "{}", "params": {}}}"#,
+            $self.id.load(Ordering::Relaxed),
+            $method,
+            serde_json::to_value(($($params,)*)).unwrap()
+        );
+        $self.id.fetch_add(1, Ordering::Relaxed);
+
+        let req_json: serde_json::Value = serde_json::from_str(&data).unwrap();
+
+        let url = match $id {
+            Target::CKB => $self.ckb_uri.clone(),
+            Target::Indexer => $self.indexer_uri.clone(),
+        };
+        let c = $self.raw.post(url).json(&req_json);
+        async {
+            let resp = c
+                .send()
+                .await
+                .map_err::<Error, _>(|_| Error::JsonRpcRequestError)?;
+            let output = resp
+                .json::<jsonrpc_core::response::Output>()
+                .await
+                .map_err::<Error, _>(|_| Error::JsonRpcRequestError)?;
+
+            match output {
+                jsonrpc_core::response::Output::Success(success) => {
+                    Ok(serde_json::from_value::<$return>(success.result).unwrap())
+                }
+                jsonrpc_core::response::Output::Failure(_) => {
+                    Err(Error::JsonRpcRequestError)
+                }
+            }
+        }
+    }}
+}
+
+#[derive(Clone)]
+pub struct RpcClient {
+    raw: Client,
+    ckb_uri: Url,
+    indexer_uri: Url,
+    id: Arc<AtomicU64>,
+}
+
+impl RpcClient {
+    pub fn new(ckb_uri: &str, indexer_uri: &str) -> Self {
+        let ckb_uri = Url::parse(ckb_uri).expect("ckb uri, e.g. \"http://127.0.0.1:8114\"");
+        let indexer_uri = Url::parse(indexer_uri).expect("ckb uri, e.g. \"http://127.0.0.1:8116\"");
+
+        RpcClient {
+            raw: Client::new(),
+            ckb_uri,
+            indexer_uri,
+            id: Arc::new(AtomicU64::new(0)),
+        }
+    }
+}
+
+impl RpcClient {
+    pub fn get_live_cell(&self, out_point: &OutPoint, with_data: bool) -> RPC<CellWithStatus> {
+        jsonrpc!(
+            "get_live_cell",
+            Target::CKB,
+            self,
+            CellWithStatus,
+            out_point,
+            with_data
+        )
+        .boxed()
+    }
+
+    pub fn get_cells(
+        &self,
+        search_key: SearchKey,
+        limit: u32,
+        cursor: Option<JsonBytes>,
+    ) -> RPC<Pagination<Cell>> {
+        let order = Order::Asc;
+        let limit = Uint32::from(limit);
+
+        jsonrpc!(
+            "get_cells",
+            Target::Indexer,
+            self,
+            Pagination<Cell>,
+            search_key,
+            order,
+            limit,
+            cursor,
+        )
+        .boxed()
+    }
+}

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,15 +1,4 @@
-use std::{fs, path::PathBuf};
-
-#[cfg(feature = "standalone_server")]
-use std::{
-    sync::mpsc::{channel, Receiver, Sender},
-    thread,
-};
-
-use ckb_sdk::{
-    constants::TYPE_ID_CODE_HASH, rpc::ckb_indexer::Order, traits::CellQueryOptions, CkbRpcClient,
-    IndexerRpcClient,
-};
+use ckb_sdk::{constants::TYPE_ID_CODE_HASH, traits::CellQueryOptions};
 use ckb_types::{
     core::ScriptHashType,
     packed::{OutPoint, Script},
@@ -18,23 +7,22 @@ use ckb_types::{
 };
 use spore_types::generated::spore::{ClusterData, SporeData};
 
-use crate::types::{
-    ClusterDescriptionField, DecoderLocationType, Error, Settings, SporeContentField,
+use crate::{
+    client::RpcClient,
+    types::{ClusterDescriptionField, DecoderLocationType, Error, Settings, SporeContentField},
 };
 
 type DecodeResult<T> = Result<T, Error>;
 
 pub struct DOBDecoder {
-    ckb_rpc: CkbRpcClient,
-    indexer_rpc: IndexerRpcClient,
+    rpc: RpcClient,
     settings: Settings,
 }
 
 impl DOBDecoder {
     pub fn new(settings: Settings) -> Self {
         Self {
-            ckb_rpc: CkbRpcClient::new(&settings.ckb_rpc),
-            indexer_rpc: IndexerRpcClient::new(&settings.ckb_rpc),
+            rpc: RpcClient::new(&settings.ckb_rpc, &settings.ckb_rpc),
             settings,
         }
     }
@@ -43,17 +31,21 @@ impl DOBDecoder {
         self.settings.protocol_version.clone()
     }
 
-    pub fn fetch_decode_ingredients(
+    pub fn setting(&self) -> &Settings {
+        &self.settings
+    }
+
+    pub async fn fetch_decode_ingredients(
         &self,
         spore_id: [u8; 32],
     ) -> DecodeResult<(SporeContentField, ClusterDescriptionField)> {
-        let (dob_content, cluster_id) = self.fetch_dob_content(spore_id)?;
-        let dob_metadata = self.fetch_dob_metadata(cluster_id)?;
+        let (dob_content, cluster_id) = self.fetch_dob_content(spore_id).await?;
+        let dob_metadata = self.fetch_dob_metadata(cluster_id).await?;
         Ok((dob_content, dob_metadata))
     }
 
     // decode DNA under target spore_id
-    pub fn decode_dna(
+    pub async fn decode_dna(
         &self,
         dob_content: &SporeContentField,
         dob_metadata: ClusterDescriptionField,
@@ -87,13 +79,13 @@ impl DOBDecoder {
                     let Some(decoder_binary) = onchain_decoder else {
                         return Err(Error::NativeDecoderNotFound);
                     };
-                    let decoder_file_content = decoder_binary?;
+                    let decoder_file_content = decoder_binary.await?;
                     if ckb_hash::blake2b_256(&decoder_file_content)
                         != dob_metadata.dob.decoder.hash.0
                     {
                         return Err(Error::DecoderBinaryHashInvalid);
                     }
-                    fs::write(decoder_path.clone(), decoder_file_content)
+                    std::fs::write(decoder_path.clone(), decoder_file_content)
                         .map_err(|_| Error::DecoderBinaryPathInvalid)?;
                 }
                 decoder_path
@@ -105,9 +97,10 @@ impl DOBDecoder {
                     hex::encode(&dob_metadata.dob.decoder.hash)
                 ));
                 if !decoder_path.exists() {
-                    let decoder_binary =
-                        self.fetch_decoder_binary(dob_metadata.dob.decoder.hash.into())?;
-                    fs::write(decoder_path.clone(), decoder_binary)
+                    let decoder_binary = self
+                        .fetch_decoder_binary(dob_metadata.dob.decoder.hash.into())
+                        .await?;
+                    std::fs::write(decoder_path.clone(), decoder_binary)
                         .map_err(|_| Error::DecoderBinaryPathInvalid)?;
                 }
                 decoder_path
@@ -175,14 +168,18 @@ impl DOBDecoder {
     }
 
     // search on-chain spore cell and return its content field, which represents dob content
-    fn fetch_dob_content(&self, spore_id: [u8; 32]) -> DecodeResult<(SporeContentField, [u8; 32])> {
+    async fn fetch_dob_content(
+        &self,
+        spore_id: [u8; 32],
+    ) -> DecodeResult<(SporeContentField, [u8; 32])> {
         let mut spore_cell = None;
         for spore_search_option in
             build_batch_search_options(spore_id, &self.settings.avaliable_spore_code_hashes)
         {
             spore_cell = self
-                .indexer_rpc
-                .get_cells(spore_search_option.into(), Order::Asc, 1.into(), None)
+                .rpc
+                .get_cells(spore_search_option.into(), 1, None)
+                .await
                 .map_err(|_| Error::FetchLiveCellsError)?
                 .objects
                 .first()
@@ -217,14 +214,18 @@ impl DOBDecoder {
     }
 
     // search on-chain cluster cell and return its description field, which contains dob metadata
-    fn fetch_dob_metadata(&self, cluster_id: [u8; 32]) -> DecodeResult<ClusterDescriptionField> {
+    async fn fetch_dob_metadata(
+        &self,
+        cluster_id: [u8; 32],
+    ) -> DecodeResult<ClusterDescriptionField> {
         let mut cluster_cell = None;
         for cluster_search_option in
             build_batch_search_options(cluster_id, &self.settings.avaliable_cluster_code_hashes)
         {
             cluster_cell = self
-                .indexer_rpc
-                .get_cells(cluster_search_option.into(), Order::Asc, 1.into(), None)
+                .rpc
+                .get_cells(cluster_search_option.into(), 1, None)
+                .await
                 .map_err(|_| Error::FetchLiveCellsError)?
                 .objects
                 .first()
@@ -246,11 +247,12 @@ impl DOBDecoder {
     }
 
     // search on-chain decoder cell, deployed with type_id feature enabled
-    fn fetch_decoder_binary(&self, decoder_id: [u8; 32]) -> DecodeResult<Vec<u8>> {
+    async fn fetch_decoder_binary(&self, decoder_id: [u8; 32]) -> DecodeResult<Vec<u8>> {
         let decoder_search_option = build_type_id_search_option(decoder_id);
         let decoder_cell = self
-            .indexer_rpc
-            .get_cells(decoder_search_option.into(), Order::Asc, 1.into(), None)
+            .rpc
+            .get_cells(decoder_search_option.into(), 1, None)
+            .await
             .map_err(|_| Error::FetchLiveCellsError)?
             .objects
             .first()
@@ -264,14 +266,15 @@ impl DOBDecoder {
     }
 
     // search on-chain decoder cell, directly by its tx_hash and out_index
-    fn fetch_decoder_binary_directly(
+    async fn fetch_decoder_binary_directly(
         &self,
         tx_hash: H256,
         out_index: u32,
     ) -> DecodeResult<Vec<u8>> {
         let decoder_cell = self
-            .ckb_rpc
-            .get_live_cell(OutPoint::new(tx_hash.pack(), out_index).into(), true)
+            .rpc
+            .get_live_cell(&OutPoint::new(tx_hash.pack(), out_index).into(), true)
+            .await
             .map_err(|_| Error::FetchTransactionError)?;
         let decoder_binary = decoder_cell
             .cell
@@ -307,108 +310,4 @@ fn build_batch_search_options(
             CellQueryOptions::new_type(type_script)
         })
         .collect()
-}
-
-enum DecoderCommand {
-    ProtocolVersion(Sender<String>),
-    DecodeDNA([u8; 32], Sender<DecodeResult<(String, SporeContentField)>>),
-    Stop,
-}
-
-pub struct DecoderCmdSender {
-    sender: Sender<DecoderCommand>,
-    cache_path: PathBuf,
-}
-
-impl DecoderCmdSender {
-    fn new(sender: Sender<DecoderCommand>, cache_path: PathBuf) -> Self {
-        Self { sender, cache_path }
-    }
-
-    pub fn protocol_version(&self) -> String {
-        let (tx, rx) = channel();
-        self.sender
-            .send(DecoderCommand::ProtocolVersion(tx))
-            .unwrap();
-        rx.recv().unwrap()
-    }
-
-    pub fn decode_dna(&self, hexed_spore_id: &str) -> DecodeResult<(String, SporeContentField)> {
-        let spore_id: [u8; 32] = hex::decode(hexed_spore_id)
-            .map_err(|_| Error::HexedSporeIdParseError)?
-            .try_into()
-            .map_err(|_| Error::SporeIdLengthInvalid)?;
-        let mut cache_path = self.cache_path.clone();
-        cache_path.push(format!("{}.dob", hex::encode(&spore_id)));
-        if cache_path.exists() {
-            read_dob_from_cache(cache_path)
-        } else {
-            let (tx, rx) = channel();
-            self.sender
-                .send(DecoderCommand::DecodeDNA(spore_id, tx))
-                .unwrap();
-            let (output, content) = rx.recv().unwrap()?;
-            write_dob_to_cache(&output, &content, cache_path);
-            Ok((output, content))
-        }
-    }
-
-    pub fn stop(&self) {
-        self.sender.send(DecoderCommand::Stop).unwrap();
-    }
-}
-
-pub struct DOBThreadDecoder {
-    rx: Receiver<DecoderCommand>,
-    decoder: DOBDecoder,
-}
-
-impl DOBThreadDecoder {
-    pub fn new(settings: Settings) -> (Self, DecoderCmdSender) {
-        let (tx, rx) = channel();
-        let decoder = DOBDecoder::new(settings);
-        let cmd = DecoderCmdSender::new(tx, decoder.settings.dobs_cache_directory.clone());
-        (Self { rx, decoder }, cmd)
-    }
-
-    pub fn run(self) {
-        thread::spawn(move || loop {
-            match self.rx.recv().unwrap() {
-                DecoderCommand::Stop => break,
-                DecoderCommand::ProtocolVersion(response) => {
-                    let version = self.decoder.protocol_version();
-                    response.send(version).unwrap();
-                }
-                DecoderCommand::DecodeDNA(spore_id, response) => {
-                    match self.decoder.fetch_decode_ingredients(spore_id) {
-                        Ok((content, metadata)) => {
-                            match self.decoder.decode_dna(&content, metadata) {
-                                Ok(output) => response.send(Ok((output, content))).unwrap(),
-                                Err(error) => response.send(Err(error)).unwrap(),
-                            }
-                        }
-                        Err(error) => response.send(Err(error)).unwrap(),
-                    }
-                }
-            }
-        });
-    }
-}
-
-fn read_dob_from_cache(cache_path: PathBuf) -> DecodeResult<(String, SporeContentField)> {
-    let file_content = fs::read_to_string(cache_path).expect("read dob");
-    let mut lines = file_content.split('\n');
-    let (Some(result), Some(content)) = (lines.next(), lines.next()) else {
-        return Err(Error::DOBRenderCacheModified);
-    };
-    match serde_json::from_str::<SporeContentField>(content) {
-        Ok(content) => Ok((result.to_string(), content)),
-        Err(_) => Err(Error::DOBRenderCacheModified),
-    }
-}
-
-fn write_dob_to_cache(render_result: &str, dob_content: &SporeContentField, cache_path: PathBuf) {
-    let json_dob_content = serde_json::to_string(dob_content).unwrap();
-    let file_content = format!("{render_result}\n{json_dob_content}");
-    fs::write(cache_path, file_content).expect("write dob");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod client;
 pub mod decoder;
 pub mod types;
 
@@ -8,7 +9,7 @@ mod vm;
 mod test {
     use ckb_types::{h256, H256};
 
-    use crate::decoder::{DOBDecoder, DOBThreadDecoder};
+    use crate::decoder::DOBDecoder;
     use crate::types::{
         ClusterDescriptionField, DOBClusterFormat, DOBDecoderFormat, DecoderLocationType, Settings,
         SporeContentField,
@@ -16,8 +17,6 @@ mod test {
 
     const EXPECTED_UNICORN_RENDER_RESULT: &str = "[{\"name\":\"Spirits\",\"traits\":[{\"String\":\"Metal, Golden Body\"}]},{\"name\":\"Yin Yang\",\"traits\":[{\"String\":\"Yang, Short Hair\"}]},{\"name\":\"Talents\",\"traits\":[{\"String\":\"Forget\"}]},{\"name\":\"Horn\",\"traits\":[{\"String\":\"Necromancer Horn\"}]},{\"name\":\"Wings\",\"traits\":[{\"String\":\"Lightning Wings\"}]},{\"name\":\"Tails\",\"traits\":[{\"String\":\"Dumbledore Tails\"}]},{\"name\":\"Horseshoes\",\"traits\":[{\"String\":\"Colorful Stone Horseshoes\"}]},{\"name\":\"Destiny Number\",\"traits\":[{\"Number\":59576}]},{\"name\":\"Lucky Number\",\"traits\":[{\"Number\":3}]}]";
     const EXPECTED_NERVAPE_RENDER_RESULT: &str = "[{\"name\":\"prev.type\",\"traits\":[{\"String\":\"text\"}]},{\"name\":\"prev.bg\",\"traits\":[{\"String\":\"btcfs://59e87ca177ef0fd457e87e9f93627660022cf519b531e1f4e3a6dda9e5e33827i0\"}]},{\"name\":\"prev.bgcolor\",\"traits\":[{\"String\":\"#CEBAF7\"}]},{\"name\":\"Background\",\"traits\":[{\"Number\":170}]},{\"name\":\"Suit\",\"traits\":[{\"Number\":236}]},{\"name\":\"Upper body\",\"traits\":[{\"Number\":53}]},{\"name\":\"Lower body\",\"traits\":[{\"Number\":189}]},{\"name\":\"Headwear\",\"traits\":[{\"Number\":175}]},{\"name\":\"Mask\",\"traits\":[{\"Number\":153}]},{\"name\":\"Eyewear\",\"traits\":[{\"Number\":126}]},{\"name\":\"Mouth\",\"traits\":[{\"Number\":14}]},{\"name\":\"Ears\",\"traits\":[{\"Number\":165}]},{\"name\":\"Tattoo\",\"traits\":[{\"Number\":231}]},{\"name\":\"Accessory\",\"traits\":[{\"Number\":78}]},{\"name\":\"Handheld\",\"traits\":[{\"Number\":240}]},{\"name\":\"Special\",\"traits\":[{\"Number\":70}]}]";
-    const HEXED_NERVAPE_SPORE_ID: &str =
-        "9dd9604d44d6640d1533c9f97f89438f17526e645f6c35aa08d8c7d844578580";
     const NERVAPE_SPORE_ID: H256 =
         h256!("0x9dd9604d44d6640d1533c9f97f89438f17526e645f6c35aa08d8c7d844578580");
 
@@ -104,61 +103,51 @@ mod test {
         (unicorn_content, unicorn_metadata)
     }
 
-    fn decode_unicorn_dna(onchain_decoder: bool) -> String {
+    async fn decode_unicorn_dna(onchain_decoder: bool) -> String {
         let settings = prepare_settings("text/plain");
         let decoder = DOBDecoder::new(settings);
         let (unicorn_content, unicorn_metadata) = generate_unicorn_dob_ingredients(onchain_decoder);
         decoder
             .decode_dna(&unicorn_content, unicorn_metadata)
+            .await
             .expect("decode")
     }
 
-    #[test]
-    fn test_decode_unicorn_dna() {
-        let render_result = decode_unicorn_dna(false);
+    #[tokio::test]
+    async fn test_decode_unicorn_dna() {
+        let render_result = decode_unicorn_dna(false).await;
         assert_eq!(render_result, EXPECTED_UNICORN_RENDER_RESULT);
     }
 
-    #[test]
-    fn test_decode_unicorn_dna_with_onchain_decoder() {
-        let render_result = decode_unicorn_dna(true);
+    #[tokio::test]
+    async fn test_decode_unicorn_dna_with_onchain_decoder() {
+        let render_result = decode_unicorn_dna(true).await;
         assert_eq!(render_result, EXPECTED_UNICORN_RENDER_RESULT);
     }
 
-    #[test]
-    fn test_fetch_and_decode_nervape_dna() {
+    #[tokio::test]
+    async fn test_fetch_and_decode_nervape_dna() {
         let settings = prepare_settings("text/plain");
         let decoder = DOBDecoder::new(settings);
         let (dob_content, dob_metadata) = decoder
             .fetch_decode_ingredients(NERVAPE_SPORE_ID.into())
+            .await
             .expect("fetch");
         let render_result = decoder
             .decode_dna(&dob_content, dob_metadata)
+            .await
             .expect("decode");
         assert_eq!(render_result, EXPECTED_NERVAPE_RENDER_RESULT);
     }
 
-    #[test]
+    #[tokio::test]
     #[should_panic = "fetch: DOBVersionUnexpected"]
-    fn test_fetch_onchain_dob_failed() {
+    async fn test_fetch_onchain_dob_failed() {
         let settings = prepare_settings("dob/0");
         DOBDecoder::new(settings)
             .fetch_decode_ingredients(NERVAPE_SPORE_ID.into())
+            .await
             .expect("fetch");
-    }
-
-    #[test]
-    fn test_decode_onchain_nervape_dna_in_thread() {
-        let protocol_version = "text/plain";
-        let settings = prepare_settings(protocol_version);
-        let (decoder, cmd) = DOBThreadDecoder::new(settings);
-        decoder.run();
-        assert_eq!(cmd.protocol_version(), protocol_version);
-        let (render_result, _) = cmd
-            .decode_dna(HEXED_NERVAPE_SPORE_ID)
-            .expect("thread decode");
-        assert_eq!(render_result, EXPECTED_NERVAPE_RENDER_RESULT);
-        cmd.stop();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
+mod vm;
+
 pub mod client;
 pub mod decoder;
 pub mod types;
-
-#[cfg(feature = "embeded_vm")]
-mod vm;
 
 #[cfg(test)]
 mod test {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
-use std::{fs, sync::Arc};
+use std::fs;
 
 use jsonrpsee::{server::ServerBuilder, tracing};
 use server::DecoderRpcServer;
 use tracing_subscriber::EnvFilter;
 
+mod client;
 mod decoder;
 mod server;
 mod types;
@@ -13,7 +14,8 @@ mod vm;
 
 const SETTINGS_FILE: &str = "./settings.toml";
 
-fn main() {
+#[tokio::main]
+async fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .init();
@@ -26,26 +28,19 @@ fn main() {
         serde_json::to_string_pretty(&settings).unwrap()
     );
     let rpc_server_address = settings.rpc_server_address.clone();
-    let (decoder, decoder_cmd) = decoder::DOBThreadDecoder::new(settings);
-    decoder.run();
+    let decoder = decoder::DOBDecoder::new(settings);
 
     tracing::info!("running decoder server at {}", rpc_server_address);
-    tokio::runtime::Runtime::new()
-        .unwrap()
-        .block_on(async move {
-            let http_server = ServerBuilder::new()
-                .http_only()
-                .build(rpc_server_address)
-                .await
-                .expect("build http_server");
+    let http_server = ServerBuilder::new()
+        .http_only()
+        .build(rpc_server_address)
+        .await
+        .expect("build http_server");
 
-            let decoder_cmd = Arc::new(decoder_cmd);
-            let rpc_methods = server::DecoderStandaloneServer::new(decoder_cmd.clone());
-            let handler = http_server.start(rpc_methods.into_rpc());
+    let rpc_methods = server::DecoderStandaloneServer::new(decoder);
+    let handler = http_server.start(rpc_methods.into_rpc());
 
-            tokio::signal::ctrl_c().await.unwrap();
-            tracing::info!("stopping decoder server");
-            handler.stop().unwrap();
-            decoder_cmd.stop();
-        });
+    tokio::signal::ctrl_c().await.unwrap();
+    tracing::info!("stopping decoder server");
+    handler.stop().unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,6 @@ mod client;
 mod decoder;
 mod server;
 mod types;
-
-#[cfg(feature = "embeded_vm")]
 mod vm;
 
 const SETTINGS_FILE: &str = "./settings.toml";

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,12 +55,16 @@ pub enum Error {
     DOBContentUnexpected,
     #[error("cluster description cannot parse to DOB metadata")]
     DOBMetadataUnexpected,
+    #[error("DOB render cache folder not found")]
+    DOBRenderCacheNotFound,
     #[error("cached DOB render result file has changed unexpectedly")]
     DOBRenderCacheModified,
     #[error("invalid deployed on-chain decoder code_hash")]
     DecoderBinaryHashInvalid,
     #[error("no binary found in cell for decoder")]
     DecoderBinaryNotFoundInCell,
+    #[error("error ocurred while requesing json-rpc")]
+    JsonRpcRequestError,
 }
 
 #[cfg(feature = "standalone_server")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,7 @@ use jsonrpsee::types::ErrorCode;
 #[cfg(feature = "standalone_server")]
 use serde::Serialize;
 
+#[allow(clippy::enum_variant_names)]
 #[derive(thiserror::Error, Debug)]
 #[repr(i32)]
 pub enum Error {


### PR DESCRIPTION
# Description
since `ckb-std` runs an internal tokio runtime, it's not easy to integrate its CkbRpc and IndexerRpc in a cocurrent formula, so the best way is to implement a standalone JsonRpc client to achieve this.

BTW, a batch decoding is in demand, so we added a new method `dob_batch_decode` to support it.

# Related Issues
- [x] #5 
- [x] #8  