### PR TITLE
chore: enrich error message in rpc response while in case of failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Provide an one-step DOB rendering service to squash a batch of complex steps that from DNA fetching to DOB traits rendering.
 
 Online features:
+
 - [x] embeded `ckb-vm` executor
 - [x] executable standalone JsonRpc server
 - [x] decoder binaries temporary cache
@@ -59,37 +60,3 @@ Spore DOB protocol has unique version identifier (like ERC721 or ERC1155), howev
 ## Error codes
 
 refer to error definitions [here](https://github.com/sporeprotocol/dob-decoder-standalone-server/blob/master/src/types.rs#L13).
-
-| error code | short definition |
-| -------- | ------- |
-| 1001 | DnaLengthNotMatch |
-| 1002 | SporeIdLengthInvalid |
-| 1003 | NativeDecoderNotFound |
-| 1004 | SporeIdNotFound |
-| 1005 | SporeDataUncompatible |
-| 1006 | SporeDataContentTypeUncompatible |
-| 1007 | DOBVersionUnexpected |
-| 1008 | ClusterIdNotSet |
-| 1009 | ClusterIdNotFound |
-| 1010 | ClusterDataUncompatible |
-| 1011 | DecoderIdNotFound |
-| 1012 | DecoderOutputInvalid |
-| 1013 | HexedDNAParseError |
-| 1014 | HexedSporeIdParseError |
-| 1015 | DecoderBinaryPathInvalid |
-| 1016 | DecoderExecutionError |
-| 1017 | DecoderExecutionInternalError |
-| 1018 | FetchLiveCellsError |
-| 1019 | FetchTransactionError |
-| 1020 | NoOutputCellInTransaction |
-| 1021 | DOBContentUnexpected |
-| 1022 | DOBMetadataUnexpected |
-| 1023 | DOBRenderCacheNotFound |
-| 1024 | DOBRenderCacheModified |
-| 1025 | DecoderBinaryHashInvalid |
-| 1026 | DecoderBinaryNotFoundInCell |
-| 1027 | JsonRpcRequestError |
-| 1028 | SystemTimeError |
-| 1029 | DecoderHashNotFound |
-| 1030 | DecoderScriptNotFound |
-| 1031 | DecoderChainIsEmpty |

--- a/src/client.rs
+++ b/src/client.rs
@@ -42,18 +42,18 @@ macro_rules! jsonrpc {
             let resp = c
                 .send()
                 .await
-                .map_err::<Error, _>(|_| Error::JsonRpcRequestError)?;
+                .map_err::<Error, _>(|e| Error::JsonRpcRequestError(e.to_string()))?;
             let output = resp
                 .json::<jsonrpc_core::response::Output>()
                 .await
-                .map_err::<Error, _>(|_| Error::JsonRpcRequestError)?;
+                .map_err::<Error, _>(|e| Error::JsonRpcRequestError(e.to_string()))?;
 
             match output {
                 jsonrpc_core::response::Output::Success(success) => {
                     Ok(serde_json::from_value::<$return>(success.result).unwrap())
                 }
-                jsonrpc_core::response::Output::Failure(_) => {
-                    Err(Error::JsonRpcRequestError)
+                jsonrpc_core::response::Output::Failure(e) => {
+                    Err(Error::JsonRpcRequestError(e.error.to_string()))
                 }
             }
         }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -66,7 +66,7 @@ impl DOBDecoder {
                 &decoder_path.to_string_lossy(),
                 vec![dna.to_owned().into(), pattern.into()],
             )
-            .map_err(|_| Error::DecoderExecutionError)?;
+            .map_err(|e| Error::DecoderExecutionError(e.to_string()))?;
             #[cfg(feature = "render_debug")]
             {
                 println!("\n-------- DOB/0 DECODE RESULT ({exit_code}) ---------");
@@ -74,9 +74,9 @@ impl DOBDecoder {
                 println!("-------- DOB/0 DECODE RESULT END ---------");
             }
             if exit_code != 0 {
-                return Err(Error::DecoderExecutionInternalError);
+                return Err(Error::DecoderExecutionInternalError(exit_code));
             }
-            outputs.first().ok_or(Error::DecoderOutputInvalid)?.clone()
+            outputs.first().ok_or(Error::DecoderOutputEmpty)?.clone()
         };
         Ok(raw_render_result)
     }
@@ -105,7 +105,7 @@ impl DOBDecoder {
                 };
                 let (exit_code, outputs) =
                     crate::vm::execute_riscv_binary(&decoder_path.to_string_lossy(), args)
-                        .map_err(|_| Error::DecoderExecutionError)?;
+                        .map_err(|e| Error::DecoderExecutionError(e.to_string()))?;
                 #[cfg(feature = "render_debug")]
                 {
                     println!("\n-------- DOB/1 DECODE RESULT ({i} => {exit_code}) ---------");
@@ -113,9 +113,9 @@ impl DOBDecoder {
                     println!("-------- DOB/1 DECODE RESULT END ---------");
                 }
                 if exit_code != 0 {
-                    return Err(Error::DecoderExecutionInternalError);
+                    return Err(Error::DecoderExecutionInternalError(exit_code));
                 }
-                outputs.first().ok_or(Error::DecoderOutputInvalid)?.clone()
+                outputs.first().ok_or(Error::DecoderOutputEmpty)?.clone()
             };
             output = Some(
                 serde_json::from_str(&raw_render_result)


### PR DESCRIPTION
# Description

replace simple error code with detailed error message, which carries more information for debugging

### Example:

previous error: 
```
{
  "code": 1014
}
```

current error:
```
{
  "code": -1,
  "message": "spore id string is not in hex format"
}
```

### Consequences

ccc/spore should be modified to apply this change